### PR TITLE
Apply withAuthorization HOC to pages and components

### DIFF
--- a/front/src/components/Instant.jsx
+++ b/front/src/components/Instant.jsx
@@ -4,8 +4,9 @@ import { useGetCallById } from "../hooks/useGetCallById";
 import MeetingSetup from "./MeetingSetup";
 import MeetingRoom from "./MeetingRoom";
 import { useSelector } from "react-redux"; // Import useSelector
+import { withAuthorization } from "../HOC/Protect";
 
-export default function Instant() {
+function Instant() {
   const currentLanguage = useSelector((state) => state.language.language); // Get current language
   const token = localStorage.getItem("token");
   const [callId, setCallId] = useState(null);
@@ -47,3 +48,5 @@ export default function Instant() {
     </StreamCall>
   );
 }
+
+export default withAuthorization(Instant, ["admin", "teacher", "coordinator"]);

--- a/front/src/components/Recorder.jsx
+++ b/front/src/components/Recorder.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { useRecordings } from "../hooks/useRecordings";
+import { withAuthorization } from "../HOC/Protect";
 
-export default function Recorder() {
+function Recorder() {
   const token = useSelector((state) => state.user.token);
   const { recordings, downloadRecording } = useRecordings(token);
   return (
@@ -21,3 +22,5 @@ export default function Recorder() {
     </ul>
   );
 }
+
+export default withAuthorization(Recorder, ["admin", "coordinator"]);

--- a/front/src/components/ScheduleForm.jsx
+++ b/front/src/components/ScheduleForm.jsx
@@ -1,8 +1,9 @@
 import React from "react";
 import { useSelector } from "react-redux";
 import { useScheduleMeeting } from "../hooks/useScheduleMeeting";
+import { withAuthorization } from "../HOC/Protect";
 
-export default function ScheduleForm() {
+function ScheduleForm() {
   const token = useSelector((state) => state.user.token);
   const { schedule, loading } = useScheduleMeeting(token);
   const handleSubmit = (e) => {
@@ -44,3 +45,5 @@ export default function ScheduleForm() {
     </form>
   );
 }
+
+export default withAuthorization(ScheduleForm, ["admin", "teacher", "coordinator"]);

--- a/front/src/pages/Calendar.jsx
+++ b/front/src/pages/Calendar.jsx
@@ -39,6 +39,7 @@ import { useGetUsers } from "../hooks/useGetUsers";
 import { useStreamVideoClient } from "@stream-io/video-react-sdk";
 import MeetingModal from "../components/MeetingModal";
 import ReactSelect from "react-select";
+import { withAuthorization } from "../HOC/Protect";
 
 const CalendarPage = () => {
   const calendarRef = useRef(null);
@@ -658,4 +659,4 @@ const CalendarPage = () => {
   );
 };
 
-export default CalendarPage;
+export default withAuthorization(CalendarPage, ["admin", "teacher", "coordinator", "student"]);

--- a/front/src/pages/CommentsPage.jsx
+++ b/front/src/pages/CommentsPage.jsx
@@ -22,6 +22,7 @@ import {
   Flex,
 } from "@chakra-ui/react";
 // Removed: import { t } from '../utils/translations';
+import { withAuthorization } from "../HOC/Protect";
 
 const CommentsPage = () => {
   const [comments, setComments] = useState([]);
@@ -569,4 +570,4 @@ const CommentsPage = () => {
   );
 };
 
-export default CommentsPage;
+export default withAuthorization(CommentsPage, ["admin", "coordinator"]);

--- a/front/src/pages/PaymentProof.jsx
+++ b/front/src/pages/PaymentProof.jsx
@@ -29,6 +29,7 @@ import { useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { useGetUsers } from "../hooks/useGetUsers";
 import dayjs from "dayjs";
+import { withAuthorization } from "../HOC/Protect";
 
 const labels = {
   student: { en: "Student", fr: "Élève", ar: "تلميذ" },
@@ -83,7 +84,7 @@ const fetchProofs = async () => {
   return data.data;
 };
 
-export default function PaymentProofsPage() {
+function PaymentProofsPage() {
   const language = useSelector((state) => state.language.language);
   const user = useSelector((state) => state.user.user);
   const toast = useToast();
@@ -442,3 +443,5 @@ export default function PaymentProofsPage() {
     </Box>
   );
 }
+
+export default withAuthorization(PaymentProofsPage, ["admin", "coordinator"]);

--- a/front/src/pages/Recordings.jsx
+++ b/front/src/pages/Recordings.jsx
@@ -20,8 +20,4 @@ const PreviousPage = () => {
   );
 };
 
-export default withAuthorization(PreviousPage, [
-  "admin",
-  "coordinator",
-  // "teacher",
-]);
+export default withAuthorization(PreviousPage, ["admin", "coordinator"]);

--- a/front/src/pages/TopUp.jsx
+++ b/front/src/pages/TopUp.jsx
@@ -148,4 +148,4 @@ const TopUp = () => {
   );
 };
 
-export default withAuthorization(TopUp, ["admin", "coordinator"]);
+export default withAuthorization(TopUp, ["admin"]);

--- a/front/src/pages/WalletHistory.jsx
+++ b/front/src/pages/WalletHistory.jsx
@@ -28,6 +28,7 @@ import apiClient from "../hooks/apiClient";
 import { format } from "date-fns"; // For date formatting
 import { useSelector } from "react-redux"; // Import useSelector
 import { useMemo } from "react"; // Import useMemo
+import { withAuthorization } from "../HOC/Protect";
 
 const WalletHistory = () => {
   const currentLanguage = useSelector((state) => state.language.language); // Get current language
@@ -332,4 +333,4 @@ const WalletHistory = () => {
   );
 };
 
-export default WalletHistory;
+export default withAuthorization(WalletHistory, ["student", "teacher"]);


### PR DESCRIPTION
- Applied `withAuthorization` HOC to various pages to enforce role-based access control.
- Updated roles for pages already using the HOC to align with definitions in `sidebar.js`.
- Applied `withAuthorization` HOC to specific components (`Instant.jsx`, `Recorder.jsx`, `ScheduleForm.jsx`) to protect action initiation.
- Ensured `LandingContentManagementPage.jsx` is restricted to admin users as per initial requirements.
- Public pages and general UI components are excluded from this HOC.
- Roles considered: admin, teacher, coordinator, student.