### PR TITLE
Update email configuration to use OVH Zimbra

### DIFF
--- a/back/utils/sendEmail.js
+++ b/back/utils/sendEmail.js
@@ -4,10 +4,12 @@ if (!process.env.EMAIL_USER || !process.env.EMAIL_PASS) {
   throw new Error("EMAIL_USER and EMAIL_PASS must be set in .env");
 }
 const transporter = nodemailer.createTransport({
-  service: "Gmail",
+  host: "ssl0.ovh.net",
+  port: 465,
+  secure: true, // true for 465, false for 587
   auth: {
-    user: process.env.EMAIL_USER,
-    pass: process.env.EMAIL_PASS,
+    user: process.env.EMAIL_USER, // your email
+    pass: process.env.EMAIL_PASS, // your password
   },
 });
 /**


### PR DESCRIPTION
Modified `back/utils/sendEmail.js` to use OVH Zimbra SMTP settings instead of Gmail.

The new configuration uses:
- Host: ssl0.ovh.net
- Port: 465
- Secure: true

This change allows the application to send emails, such as verification emails, via the OVH Zimbra Starter Mail service. Environment variables `EMAIL_USER` and `EMAIL_PASS` need to be set accordingly in the deployment environment.