### PR TITLE
feat: make calendar responsive and mobile-friendly

### DIFF
--- a/front/src/hooks/useWindowSize.js
+++ b/front/src/hooks/useWindowSize.js
@@ -1,0 +1,26 @@
+import { useState, useEffect } from "react";
+
+function useWindowSize() {
+  const [windowSize, setWindowSize] = useState({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+
+    window.addEventListener("resize", handleResize);
+    handleResize();
+
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
+  return windowSize;
+}
+
+export default useWindowSize;

--- a/front/src/pages/Calendar.jsx
+++ b/front/src/pages/Calendar.jsx
@@ -40,6 +40,7 @@ import { useStreamVideoClient } from "@stream-io/video-react-sdk";
 import MeetingModal from "../components/MeetingModal";
 import ReactSelect from "react-select";
 import { withAuthorization } from "../HOC/Protect";
+import useWindowSize from "../hooks/useWindowSize";
 
 const CalendarPage = () => {
   const calendarRef = useRef(null);
@@ -47,6 +48,8 @@ const CalendarPage = () => {
   const client = useStreamVideoClient();
   const token = localStorage.getItem("token");
   const user = useSelector((state) => state.user.user);
+  const { width } = useWindowSize();
+  const isMobile = width < 768;
 
   // Early return or loading state if user is not yet populated
   if (!user) {
@@ -571,20 +574,29 @@ const CalendarPage = () => {
       <FullCalendar
         ref={calendarRef}
         plugins={[dayGridPlugin, timeGridPlugin, listPlugin, interactionPlugin]}
-        headerToolbar={{
-          left: "prev,next today",
-          center: "title",
-          right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
-        }}
-        initialView="timeGridWeek"
         selectable
         select={handleSelect}
         events={events}
         eventClick={handleEventClick}
         editable
+        selectLongPressDelay={100}
         nowIndicator
         weekends
         slotDuration="01:00:00"
+        initialView={isMobile ? "listWeek" : "timeGridWeek"}
+        headerToolbar={
+          isMobile
+            ? {
+                left: "prev,next",
+                center: "title",
+                right: "listWeek,dayGridMonth",
+              }
+            : {
+                left: "prev,next today",
+                center: "title",
+                right: "dayGridMonth,timeGridWeek,timeGridDay,listWeek",
+              }
+        }
       />
 
       {/* Type Modal */}


### PR DESCRIPTION
This commit improves the usability of the calendar on mobile devices.

The following changes were made:

- The calendar header is now responsive. A simplified header is shown on mobile devices to prevent layout issues.
- The default view on mobile is now `listWeek`, which is more suitable for small screens.
- A `selectLongPressDelay` has been added to improve the date selection experience on touch devices.
- A `useWindowSize` hook was created to help with the responsive layout.